### PR TITLE
Make Tailscale version and advertised routes configurable

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
   - type: worker
     name: render-subnet-router
     env: docker
+    region: frankfurt
     autoDeploy: false
     envVars:
       - key: TAILSCALE_AUTHKEY


### PR DESCRIPTION
- `TAILSCALE_VERSION`: Allows specifying the Tailscale version to install (defaults to 1.14.0)
- `ADVERTISE_ROUTES`: Allows customizing the routes being advertised (defaults to 10.0.0.0/8)